### PR TITLE
set engine process working directory to exe home directory

### DIFF
--- a/src/de/haukerehfeld/quakeinjector/EngineStarter.java
+++ b/src/de/haukerehfeld/quakeinjector/EngineStarter.java
@@ -23,12 +23,10 @@ import java.io.File;
 import java.util.ArrayList;
 
 public class EngineStarter {
-	private File quakeDir;
 	private File quakeExe;
 	private String quakeCmdline;
 
-	public EngineStarter(File quakeDir, File quakeExe, Configuration.EngineCommandLine quakeCmdline) {
-		this.quakeDir = quakeDir;
+	public EngineStarter(File quakeExe, Configuration.EngineCommandLine quakeCmdline) {
 		this.quakeExe = quakeExe;
 		this.quakeCmdline = quakeCmdline.get();
 	}
@@ -48,17 +46,13 @@ public class EngineStarter {
 		cmd.add(startmap);
 		
 		ProcessBuilder pb = new ProcessBuilder(cmd);
-		pb.directory(quakeDir);
+		pb.directory(quakeExe.getParentFile());
 		pb.redirectErrorStream(true);
 
 		System.out.println(cmd);
 		
 		Process p = pb.start();
 		return p;
-	}
-
-	public void setQuakeDirectory(File dir) {
-		this.quakeDir = dir;
 	}
 
 	public void setQuakeExecutable(File exe) {

--- a/src/de/haukerehfeld/quakeinjector/QuakeInjector.java
+++ b/src/de/haukerehfeld/quakeinjector/QuakeInjector.java
@@ -257,8 +257,7 @@ public class QuakeInjector extends JFrame {
 			                          + File.separator
 			                          + getConfig().EngineExecutable);
 		}
-		starter = new EngineStarter(enginePath.get(),
-		                            engineExe,
+		starter = new EngineStarter(engineExe,
 		                            getConfig().EngineCommandLine);
 		installer = new Installer(enginePath,
 		                          getConfig().DownloadPath);
@@ -606,7 +605,7 @@ public class QuakeInjector extends JFrame {
 
 		c.DownloadPath.set(downloadPath);
 
-		setEngineConfig(enginePath, engineExecutable, getConfig().EngineCommandLine, rogueInstalled, hipnoticInstalled);
+		setEngineConfig(engineExecutable, getConfig().EngineCommandLine, rogueInstalled, hipnoticInstalled);
 
 
 		try {
@@ -629,12 +628,10 @@ public class QuakeInjector extends JFrame {
 	/**
 	 * @todo 2010-02-09 12:19 hrehfeld    Let this use configuration values to their full extent
 	 */
-	private void setEngineConfig(File enginePath,
-								 File engineExecutable,
+	private void setEngineConfig(File engineExecutable,
 	                             Configuration.EngineCommandLine commandline,
 	                             boolean rogueInstalled,
 	                             boolean hipnoticInstalled) {
-		starter.setQuakeDirectory(enginePath);
 		starter.setQuakeExecutable(engineExecutable);
 		starter.setQuakeCommandline(commandline);
 


### PR DESCRIPTION
## functional changes

Previously the code was setting the working directory to be the basedir
(directory containing the id1 folder etc.) which is usually kosher but not
always.

This change sets the engine working directory to instead be the directory
actually containing the engine executable. If the engine is in the basedir
then nothing changes. New cases that will now work (that didn't) are cases
where the engine is not in the basedir, when the engine tries to find stuff
like DLLs or other resources that it expects to be in (or relative to) the
working directory.

A couple of examples of the engine not being in the basedir:
- DarkPlaces has so many libraries that I usually like to corral all its files
  into their own folder (and use the -basedir command line arg).
- Using Steam.exe to launch Quake through Steam (cf. comments 124-126 at
  http://www.celephais.net/board/view_thread.php?id=60441 ).
## code changes

The main change is in EngineStarter.start, where we now use
quakeExe.getParentFile() as the working directory.

This means that EngineStarter no longer needs to know about the basedir
(previously passed in as quakeDir) -- that's only used when managing packages,
and when constructing the quakeExe arg. So the other changes are to remove
that now-unused bit of state from EngineStarter.
